### PR TITLE
To write tests in ES6 with babel, please use babel-plugin-espower

### DIFF
--- a/config/karma.conf.js
+++ b/config/karma.conf.js
@@ -33,14 +33,14 @@ module.exports = function (config) {
         loaders: [{
           test: /\.js$/,
           exclude: /node_modules|vue\src/,
-          loader: 'babel'
+          loader: 'babel',
+          query: {
+            plugins: ['babel-plugin-espower']
+          }
         }],
         postLoaders: [{
           test: /\.json$/,
           loader: 'json'
-        }, {
-          test: /\.js$/,
-          loader: 'webpack-espower-loader'
         }, {
           test: /\.js$/,
           exclude: /test|node_modules|vue\src/,

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "babel": "^5.8.23",
     "babel-core": "^5.8.23",
     "babel-loader": "^5.3.2",
+    "babel-plugin-espower": "^1.0.0",
     "eslint": "^1.3.1",
     "istanbul-instrumenter-loader": "^0.1.3",
     "json-loader": "^0.5.2",
@@ -24,8 +25,7 @@
     "phantomjs": "^1.9.18",
     "power-assert": "^1.0.0",
     "vue": "^0.12.13",
-    "webpack": "^1.12.1",
-    "webpack-espower-loader": "^1.0.1"
+    "webpack": "^1.12.1"
   },
   "files": [
     "lib"


### PR DESCRIPTION
To write tests in ES6 with babel, please use `babel-plugin-espower` or `espower-babel` (espower-babel uses babel-plugin-espower internally). 

`webpack-espower-loader` (and other instrumentors) transforms code __after__ babel, which does not work since babel output has changed.

`babel-plugin-espower` works as babel plugin and runs __before__ babel transformation, so it works as expected.
